### PR TITLE
Disable dynamic mapping

### DIFF
--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -75,5 +75,9 @@ return [
                 ],
             ],
         ]
+    ],
+    
+    'settings' => [
+        'eloquent_reload' => true
     ]
 ];

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -52,42 +52,28 @@ return [
     | You may specify your mappings in the model if you like that approach,
     | just make a static method, e.g. mapping() and refer to it here, like:
     |
-    | 'mappings' => [
-    |     'articles' => \App\Article::mapping()
-    | ]
+    | 'articles' => [
+    |     'mapping' => \App\Models\Product::mapping()
+    | ],
     |
     */
 
     'indices' => [
-
-        'laravel' => [
+        'laravel_project' => [
             'settings' => [
                 "number_of_shards" => 1,
                 "number_of_replicas" => 0,
             ],
-            'mappings' => [
+            'types' => [
                 'articles' => [
-                    'title' => [
-                        'type' => 'string'
+                    'dynamic' => true,
+                    'mapping' => [
+                        'title' => [
+                            'type' => 'string'
+                        ]
                     ]
-                ]
-            ]
-        ],
-
-        'another_index' => [
-            'settings' => [
-                "number_of_shards" => 1,
-                "number_of_replicas" => 0,
+                ],
             ],
-            'mappings' => [
-                'articles' => [
-                    'title' => [
-                        'type' => 'string'
-                    ]
-                ]
-            ]
         ]
-
     ]
-
 ];

--- a/src/Console/ElasticMakeIndicesCommand.php
+++ b/src/Console/ElasticMakeIndicesCommand.php
@@ -47,7 +47,7 @@ class ElasticMakeIndicesCommand extends Command
 
         foreach ($indices as $index) {
 
-            $indexConfig = config("elasticsearch.indices.{$index}");
+            $indexConfig = config("elasticsearch.indices.$index");
 
             if(is_null($indexConfig)) {
                 $this->error("Config for index \"{$index}\" not found, skipping...");
@@ -65,24 +65,24 @@ class ElasticMakeIndicesCommand extends Command
             $client->indices()->create([
                 'index' => $index,
                 'body' => [
-                    "settings" => $indexConfig['settings']
+                    'settings' => $indexConfig['settings']
                 ]
             ]);
 
-            if (! isset($indexConfig['mappings'])) {
+            if (! isset($indexConfig['types'])) {
                 continue;
             }
 
-            foreach ($indexConfig['mappings'] as $type => $mapping) {
+            foreach ($indexConfig['types'] as $typeName => $type) {
 
                 // Create mapping for type, from config file
-                $this->info("- Creating mapping for: {$type}");
+                $this->info("- Creating mapping for: {$typeName}");
                 $client->indices()->putMapping([
                     'index' => $index,
-                    'type' => $type,
+                    'type' => $typeName,
                     'body' => [
-                        'dynamic' => false,
-                        'properties' => $mapping
+                        'dynamic' => isset($type['dynamic']) ? $type['dynamic'] : true,
+                        'properties' => $type['mapping']
                     ]
                 ]);
             }

--- a/src/Console/ElasticMakeIndicesCommand.php
+++ b/src/Console/ElasticMakeIndicesCommand.php
@@ -81,6 +81,7 @@ class ElasticMakeIndicesCommand extends Command
                     'index' => $index,
                     'type' => $type,
                     'body' => [
+                        'dynamic' => false,
                         'properties' => $mapping
                     ]
                 ]);

--- a/src/ElasticSearchable.php
+++ b/src/ElasticSearchable.php
@@ -41,5 +41,9 @@ trait ElasticSearchable
 
         return new ScoutBuilder($model, $query);
     }
+    
+    public function toArray(){
+        return !config('elasticsearch.settings.eloquent_reload') ? $this['attributes'] : parent::toArray();
+    }
 
 }

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -173,8 +173,10 @@ class ElasticsearchEngine extends Engine
 
         // Sorting
         if(isset($options['sorting']) && count($options['sorting'])) {
-            $params['body']['sort'] = array_merge($params['body']['sort'],
-                $options['sorting']);
+            $params['body']['sort'] = array_merge(
+                $options['sorting'],
+                $params['body']['sort']
+            );
         }
 
         return $this->elastic->search($params);
@@ -239,7 +241,11 @@ class ElasticsearchEngine extends Engine
             $key = $hit['_id'];
 
             if (isset($models[$key])) {
-                return $models[$key];
+                $model = $models[$key];
+                if(!config('elasticsearch.settings.eloquent_reload')){
+                    $model->fill($hit['_source']);
+                }
+                return $model;
             }
         })->filter();
     }


### PR DESCRIPTION
 because default toSearchableArray() method filling up with new mappings